### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,13 @@ build/*
 tcpview.pro.user
 *.autosave
 /translations/*.txt
+/.vs
+/debug
+/release
+/.qmake.stash
+/tcpview.qtvscr
+/tcpview.sln
+/tcpview.vcxproj
+/tcpview.vcxproj.filters
+/tcpview.vcxproj.user
+/ui_mainwindow.h

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,17 +3,17 @@ version: 3.0.{build}.{branch}
 environment:
   matrix:
 
-       ##Ubuntu2204 - Ubuntu 22.04 (Jammy Jellyfish)
+      #Ubuntu2204 - Ubuntu 22.04 (Jammy Jellyfish)
     - job_name: "ubuntu.22.04"
       APPVEYOR_BUILD_WORKER_IMAGE: ubuntu2204
       BUILD_FLAG: -qt=qt5
 
-      ##Ubuntu2004 - Ubuntu 20.04 (Focal Fossa)
+      #Ubuntu2004 - Ubuntu 20.04 (Focal Fossa)
     - job_name: "ubuntu.20.04"
       APPVEYOR_BUILD_WORKER_IMAGE: ubuntu2004
       BUILD_FLAG: -qt=qt5
 
-      ##Ubuntu1804 - Ubuntu 18.04 (Bionic Beaver)
+      #Ubuntu1804 - Ubuntu 18.04 (Bionic Beaver)
     - job_name: "Ubuntu.18.04"
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
       BUILD_FLAG: -qt=qt5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,32 +6,41 @@ environment:
       #Ubuntu2204 - Ubuntu 22.04 (Jammy Jellyfish)
     - job_name: "ubuntu.22.04"
       APPVEYOR_BUILD_WORKER_IMAGE: ubuntu2204
-      BUILD_FLAG: -qt=qt5
+      QT_VERSION: qt5
 
       #Ubuntu2004 - Ubuntu 20.04 (Focal Fossa)
     - job_name: "ubuntu.20.04"
       APPVEYOR_BUILD_WORKER_IMAGE: ubuntu2004
-      BUILD_FLAG: -qt=qt5
+      QT_VERSION: qt5
 
       #Ubuntu1804 - Ubuntu 18.04 (Bionic Beaver)
     - job_name: "Ubuntu.18.04"
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1804
-      BUILD_FLAG: -qt=qt5
+      QT_VERSION: qt5
 
       #Ubuntu1604 - Ubuntu 16.04 (Xenial Xerus)
     - job_name: "Ubuntu.16.04"
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
-      BUILD_FLAG: -qt=qt5
+      QT_VERSION: qt5
 
 install:
     - sh: if [ "$APPVEYOR_BUILD_WORKER_IMAGE" = "Ubuntu1804" ] || [ "$APPVEYOR_BUILD_WORKER_IMAGE" = "Ubuntu1604" ]; then sudo rm -f /etc/apt/sources.list.d/google-chrome.list; fi
     - sh: sudo apt-get update
-    - sh: sudo apt-get install -y qtbase5-dev uuid-dev
-    #sudo apt-get install -y qtbase5-dev uuid-dev g++ make
+    - sh: |
+        if [ "$QT_VERSION" = "qt6" ]; then
+          sudo apt-get install -y qt6-base-dev uuid-dev
+        else
+          sudo apt-get install -y qtbase5-dev uuid-dev
+        fi
 
 build_script:
     - sh: set -e
+    - sh: |
+        if [ "$QT_VERSION" = "qt6" ]; then
+          export QT_SELECT=qt6
+        else
+          export QT_SELECT=qt5
+        fi
     - sh: qmake --version
-    - sh: make --version
-    - sh: qmake $BUILD_FLAG
+    - sh: qmake -qt=$QT_VERSION
     - sh: make -j$(nproc)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ environment:
       BUILD_FLAG: -qt=qt5
 
 install:
+    - sh: if [ "$APPVEYOR_BUILD_WORKER_IMAGE" = "Ubuntu1804" ] || [ "$APPVEYOR_BUILD_WORKER_IMAGE" = "Ubuntu1604" ]; then sudo rm -f /etc/apt/sources.list.d/google-chrome.list; fi
     - sh: sudo apt-get update
     - sh: sudo apt-get install -y qtbase5-dev uuid-dev
     #sudo apt-get install -y qtbase5-dev uuid-dev g++ make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,11 @@ version: 3.0.{build}.{branch}
 environment:
   matrix:
 
+       ##Ubuntu2204 - Ubuntu 22.04 (Jammy Jellyfish)
+    - job_name: "ubuntu.22.04"
+      APPVEYOR_BUILD_WORKER_IMAGE: ubuntu2204
+      BUILD_FLAG: -qt=qt5
+
       ##Ubuntu2004 - Ubuntu 20.04 (Focal Fossa)
     - job_name: "ubuntu.20.04"
       APPVEYOR_BUILD_WORKER_IMAGE: ubuntu2004

--- a/source/rootmodule.h
+++ b/source/rootmodule.h
@@ -36,7 +36,6 @@
 #include <netdb.h>
 #include <uuid/uuid.h>
 #include <semaphore.h>
-#include <source/buffer.h>
 
 #define DEF_STARTCODE 0x010101010
 #define TIMEOUT_SERVER_START 1000
@@ -78,7 +77,7 @@ private:
     std::string     m_fifoNameSrv;
     std::string     m_fifoNameSrvRun;
     int             m_fifoSrv;
-    CBuffer         m_buffer;
+    std::vector<uint8_t> m_buffer;
     bool            m_abort;
 
     bool LoadProcessInodeList(unsigned int pid, int fifoSrv);
@@ -88,11 +87,8 @@ private:
     void GetCommandString(unsigned int pid, int fifoSrv);
 
     bool WriteFifo(int fifo, const char *pBuffer, size_t size);
-    int ReadFifo(int fifo, CBuffer *pBuffer);
+    int ReadFifo(int fifo, std::vector<uint8_t> *pBuffer);
 
 };
-
-
-
 
 #endif // CROOTMODULE_H


### PR DESCRIPTION
#### PR Classification
Code enhancement and refactoring for improved buffer management and build configuration.

#### PR Summary
This pull request updates the build configuration for AppVeyor to support Ubuntu 22.04 and refactors buffer handling in the `rootmodule` to use `std::vector<uint8_t>`. 
- `.gitignore`: Added entries for Visual Studio and Qt project files.
- `appveyor.yml`: Modified to conditionally install Qt5 or Qt6 based on the `QT_VERSION` variable.
- `rootmodule.cpp`: Updated `RunClient`, `WriteFifo`, and `ReadFifo` methods to ensure proper buffer sizing and changed `WriteFifo` to accept `std::vector<uint8_t>*`.
- `rootmodule.h`: Replaced `CBuffer` with `std::vector<uint8_t>` for `m_buffer` and method signatures.